### PR TITLE
NT-93: Mask profanity in Post & Comment responses (service-layer)

### DIFF
--- a/townhall/chats/models.py
+++ b/townhall/chats/models.py
@@ -17,7 +17,7 @@ class Message(models.Model):
     user = models.ForeignKey(User, on_delete=models.DO_NOTHING)
     chat = models.ForeignKey(Chat, on_delete=models.CASCADE)
     content = models.TextField()
-    image_content = CloudinaryField('image', null=True, blank=True)
+    image_content = CloudinaryField("image", null=True, blank=True)
     sent_at = models.DateTimeField(default=timezone.now)
 
     def __str__(self):
@@ -28,7 +28,7 @@ class GroupMessage(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     group_name = models.CharField(max_length=100)
     content = models.TextField()
-    image = CloudinaryField('image', blank=True, null=True)
+    image = CloudinaryField("image", blank=True, null=True)
     sent_at = models.DateTimeField(default=timezone.now)
 
     def __str__(self):

--- a/townhall/chats/serializers.py
+++ b/townhall/chats/serializers.py
@@ -68,4 +68,4 @@ class GroupMessageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = GroupMessage
-        fields = ['id', 'user', 'group_name', 'content', 'image', 'sent_at']
+        fields = ["id", "user", "group_name", "content", "image", "sent_at"]

--- a/townhall/posts/daos.py
+++ b/townhall/posts/daos.py
@@ -3,11 +3,7 @@ import typing
 from django.forms import ValidationError
 
 from .models import Post, Comment
-from .types import (
-    CreatePostData,
-    UpdatePostData,
-    CreateCommentData
-)
+from .types import CreatePostData, UpdatePostData, CreateCommentData
 
 
 class PostDao:

--- a/townhall/posts/models.py
+++ b/townhall/posts/models.py
@@ -9,7 +9,7 @@ class Post(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
     content = models.TextField()
     created_at = models.DateTimeField(default=timezone.now)
-    image = CloudinaryField('image', blank=True, null=True)
+    image = CloudinaryField("image", blank=True, null=True)
     likes = models.IntegerField(default=0)
     liked_by = models.ManyToManyField(User, blank=True, related_name="liked_posts")
 

--- a/townhall/posts/profanity.py
+++ b/townhall/posts/profanity.py
@@ -1,0 +1,43 @@
+# posts/profanity.py
+
+import re
+from typing import Iterable
+
+DEFAULT_PROFANITY_LIST = [
+    "fuck",
+    "shit",
+    "bitch",
+    "bastard",
+    "asshole",
+    "dick",
+    "piss",
+    "crap",
+    "damn",
+    "slut",
+    "whore",
+    "cunt",
+    "prick",
+    "motherfucker",
+    "nigga",
+    "nigger",
+    "faggot",
+    "fag",
+    "hell",
+    "fucker",
+]
+
+
+def make_censor(words: Iterable[str]) -> re.Pattern:
+    escaped = [re.escape(word) for word in words if word.strip()]
+    if not escaped:
+        return re.compile(r"(?!x)x")
+    return re.compile(rf"(?iu)\b(?:{'|'.join(escaped)})\b")
+
+
+_CENSOR_RE = make_censor(DEFAULT_PROFANITY_LIST)
+
+
+def censor_text(text: str) -> str:
+    if not text:
+        return text
+    return _CENSOR_RE.sub(lambda m: "*" * len(m.group(0)), text)

--- a/townhall/posts/serializers.py
+++ b/townhall/posts/serializers.py
@@ -35,9 +35,7 @@ class PostSerializer(serializers.ModelSerializer):
     user = UserMiniSerializer(read_only=True)
 
     user_id = serializers.PrimaryKeyRelatedField(
-        queryset=User.objects.all(),
-        write_only=True,
-        source="user"
+        queryset=User.objects.all(), write_only=True, source="user"
     )
 
     image = serializers.ImageField(required=False, allow_null=True)
@@ -48,7 +46,15 @@ class PostSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Post
-        fields = ["id", "user", "user_id",
-                  "content", "created_at", "image",
-                  "likes", "liked_by", "comments"]
+        fields = [
+            "id",
+            "user",
+            "user_id",
+            "content",
+            "created_at",
+            "image",
+            "likes",
+            "liked_by",
+            "comments",
+        ]
         read_only_fields = ["id", "created_at", "likes", "liked_by", "comments"]

--- a/townhall/posts/services.py
+++ b/townhall/posts/services.py
@@ -2,12 +2,10 @@ from django.forms import ValidationError
 import typing
 
 from .models import Post
-from .types import (
-    CreatePostData,
-    UpdatePostData,
-    CreateCommentData
-)
+from .types import CreatePostData, UpdatePostData, CreateCommentData
 from .daos import PostDao, CommentDao
+
+from .profanity import censor_text
 
 
 class PostServices:
@@ -15,23 +13,24 @@ class PostServices:
     def get_post(id: int) -> typing.Optional[Post]:
         try:
             post = PostDao.get_post(id=id)
-            return post
+            return _mask_post_instance(post)
         except Post.DoesNotExist:
             raise ValidationError(f"Post with the given id: {id}, does not exist.")
 
     @staticmethod
     def get_all_posts() -> typing.List[Post]:
-        return PostDao.get_all_posts()
+        posts = PostDao.get_all_posts()
+        return _mask_post_list(posts)
 
     @staticmethod
     def create_post(create_post_data: CreatePostData) -> Post:
         post = PostDao.create_post(post_data=create_post_data)
-        return post
+        return _mask_post_instance(post)
 
     @staticmethod
     def update_post(id: int, update_post_data: UpdatePostData) -> Post:
         post = PostDao.update_post(id=id, post_data=update_post_data)
-        return post
+        return _mask_post_instance(post)
 
     @staticmethod
     def delete_post(post_id: int) -> None:
@@ -45,4 +44,17 @@ class CommentServices:
     @staticmethod
     def create_comment(create_comment_data: CreateCommentData) -> None:
         comment = CommentDao.create_comment(create_comment_data=create_comment_data)
+        if hasattr(comment, "content"):
+            comment.content = censor_text(comment.content)
         return comment
+
+
+# Masking helpers
+def _mask_post_instance(post: Post) -> Post:
+    if hasattr(post, "content"):
+        post.content = censor_text(post.content)
+    return post
+
+
+def _mask_post_list(posts: typing.Iterable[Post]) -> typing.List[Post]:
+    return [_mask_post_instance(post) for post in posts]

--- a/townhall/posts/tests/test_posts_services_masking.py
+++ b/townhall/posts/tests/test_posts_services_masking.py
@@ -1,0 +1,41 @@
+from django.test import SimpleTestCase
+from unittest.mock import patch
+from types import SimpleNamespace
+
+from posts.services import PostServices
+
+
+class PostServicesMaskingTests(SimpleTestCase):
+    @patch("posts.services.PostDao.get_all_posts")
+    def test_get_all_posts_masks(self, mock_get_all):
+        mock_get_all.return_value = [SimpleNamespace(content="shit happens")]
+        posts = PostServices.get_all_posts()
+        self.assertEqual(posts[0].content, "**** happens")
+
+    @patch("posts.services.PostDao.get_post")
+    def test_get_post_masks(self, mock_get):
+        mock_get.return_value = SimpleNamespace(content="you asshole")
+        post = PostServices.get_post(1)
+        self.assertEqual(post.content, "you *******")
+
+    @patch("posts.services.PostDao.create_post")
+    def test_create_post_masks(self, mock_create):
+        # Return whatever the DAO would have saved — we only care about masking.
+        mock_create.return_value = SimpleNamespace(content="damn this bug")
+
+        class CreatePostData:
+            def __init__(self, content):
+                self.content = content
+
+        post = PostServices.create_post(CreatePostData(content="damn this bug"))
+        self.assertEqual(post.content, "**** this bug")
+
+    @patch("posts.services.PostDao.update_post")
+    def test_update_post_masks(self, mock_update):
+        mock_update.return_value = SimpleNamespace(content="you BITCH!")
+
+        class UpdatePostData:
+            pass
+
+        post = PostServices.update_post(1, UpdatePostData())
+        self.assertEqual(post.content, "you *****!")

--- a/townhall/posts/tests/test_profanity.py
+++ b/townhall/posts/tests/test_profanity.py
@@ -1,0 +1,15 @@
+from django.test import SimpleTestCase
+from posts.profanity import censor_text
+
+
+class CensorTextTests(SimpleTestCase):
+    def test_examples(self):
+        self.assertEqual(censor_text("this is shit"), "this is ****")
+        self.assertEqual(censor_text("ShIt happens"), "**** happens")
+        self.assertEqual(censor_text("what the hell?"), "what the ****?")
+        self.assertEqual(censor_text("class"), "class")  # no false positive
+        self.assertEqual(censor_text("you BITCH!"), "you *****!")
+        self.assertEqual(censor_text("motherfucker"), "************")
+        self.assertEqual(censor_text("fuck you"), "**** you")
+        self.assertEqual(censor_text("motherfucker's"), "************'s")
+        self.assertEqual(censor_text("shit-faced"), "****-faced")

--- a/townhall/posts/urls.py
+++ b/townhall/posts/urls.py
@@ -17,33 +17,29 @@ urlpatterns = [
     path(
         "post/<int:pk>/",
         PostViewSet.as_view(
-            {
-                "get": "get_post",
-                "patch": "update_post",
-                "delete": "delete_post"
-            }
+            {"get": "get_post", "patch": "update_post", "delete": "delete_post"}
         ),
-        name="post_id"
+        name="post_id",
     ),
     path(
         "post/<int:pk>/like/",
-        PostViewSet.as_view(
-            {
-                "patch": "like_post"
-            }
-        ),
+        PostViewSet.as_view({"patch": "like_post"}),
     ),
     path(
         "comment/",
-        CommentViewSet.as_view({
-            "post": "create_comment",
-        }),
-        name="comment"
+        CommentViewSet.as_view(
+            {
+                "post": "create_comment",
+            }
+        ),
+        name="comment",
     ),
     path(
         "comment/<int:pk>/",
-        CommentViewSet.as_view({
-            "delete": "destroy",
-        }),
+        CommentViewSet.as_view(
+            {
+                "delete": "destroy",
+            }
+        ),
     ),
 ]

--- a/townhall/posts/views.py
+++ b/townhall/posts/views.py
@@ -19,14 +19,12 @@ class PostViewSet(viewsets.ModelViewSet):
         try:
             post = PostServices.get_post(id=pk)
             serializer = PostSerializer(post)
-            return Response({
-                "message": "Post fetched successfully",
-                "post": serializer.data
-            }, status=status.HTTP_200_OK)
+            return Response(
+                {"message": "Post fetched successfully", "post": serializer.data},
+                status=status.HTTP_200_OK,
+            )
         except Exception as e:
-            return Response({
-                "error": str(e)
-            }, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
     # GET ALL POSTS
     @action(detail=False, methods=["get"], url_path="post")
@@ -34,14 +32,14 @@ class PostViewSet(viewsets.ModelViewSet):
         try:
             posts = PostServices.get_all_posts()
             serializer = PostSerializer(posts, many=True)
-            return Response({
-                "message": "Posts fetched successfully",
-                "posts": serializer.data
-            }, status=status.HTTP_200_OK)
+            return Response(
+                {"message": "Posts fetched successfully", "posts": serializer.data},
+                status=status.HTTP_200_OK,
+            )
         except Exception as e:
-            return Response({
-                "error": str(e)
-                }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     # CREATE POST
     @action(detail=False, methods=["post"], url_path="post")
@@ -81,8 +79,7 @@ class PostViewSet(viewsets.ModelViewSet):
             post = Post.objects.get(pk=pk)
         except Post.DoesNotExist:
             return Response(
-                {"error": "Post not found"},
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND
             )
 
         serializer = PostSerializer(post, data=request.data, partial=True)
@@ -96,11 +93,11 @@ class PostViewSet(viewsets.ModelViewSet):
         )
 
         from .services import PostServices as PostServices
+
         PostServices.update_post(pk, update_post_data)
 
         return Response(
-            {"message": "Post Updated Successfully"},
-            status=status.HTTP_200_OK
+            {"message": "Post Updated Successfully"}, status=status.HTTP_200_OK
         )
 
     # DELETE A POST
@@ -110,13 +107,10 @@ class PostViewSet(viewsets.ModelViewSet):
             PostServices.delete_post(post_id=pk)
             return Response(
                 {"message": "Post deleted successfully"},
-                status=status.HTTP_204_NO_CONTENT
+                status=status.HTTP_204_NO_CONTENT,
             )
         except ValidationError as e:
-            return Response(
-                {"error": str(e)},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
     # LIKE A POST
     @action(detail=True, methods=["patch"], url_path="like")
@@ -128,16 +122,14 @@ class PostViewSet(viewsets.ModelViewSet):
             user_id = request.session.get("_auth_user_id")
             if not user_id:
                 return Response(
-                    {"error": "Not authenticated"},
-                    status=status.HTTP_401_UNAUTHORIZED
+                    {"error": "Not authenticated"}, status=status.HTTP_401_UNAUTHORIZED
                 )
 
             try:
                 user = User.objects.get(id=user_id)
             except User.DoesNotExist:
                 return Response(
-                    {"error": "User not found"},
-                    status=status.HTTP_400_BAD_REQUEST
+                    {"error": "User not found"}, status=status.HTTP_400_BAD_REQUEST
                 )
 
             if user in post.liked_by.all():
@@ -145,28 +137,21 @@ class PostViewSet(viewsets.ModelViewSet):
                 post.likes -= 1
                 post.save()
                 return Response(
-                    {
-                        "message": "Post unliked",
-                        "likes": post.likes
-                    },
-                    status=status.HTTP_200_OK
+                    {"message": "Post unliked", "likes": post.likes},
+                    status=status.HTTP_200_OK,
                 )
             else:
                 post.liked_by.add(user)
                 post.likes += 1
                 post.save()
                 return Response(
-                    {
-                        "message": "Post liked",
-                        "likes": post.likes
-                    },
-                    status=status.HTTP_200_OK
+                    {"message": "Post liked", "likes": post.likes},
+                    status=status.HTTP_200_OK,
                 )
 
         except Post.DoesNotExist:
             return Response(
-                {"error": "Post not found"},
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "Post not found"}, status=status.HTTP_404_NOT_FOUND
             )
 
 
@@ -215,28 +200,24 @@ class CommentViewSet(viewsets.ModelViewSet):
             comment = self.get_object()
         except Comment.DoesNotExist:
             return Response(
-                {"error": "Comment not found"},
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "Comment not found"}, status=status.HTTP_404_NOT_FOUND
             )
 
         # Get current user from session
         user_id = request.session.get("_auth_user_id")
         if not user_id:
             return Response(
-                {"error": "Not authenticated"},
-                status=status.HTTP_401_UNAUTHORIZED
+                {"error": "Not authenticated"}, status=status.HTTP_401_UNAUTHORIZED
             )
 
         # Allow only the author to delete
         if comment.user.id != int(user_id):
             return Response(
-                {"error": "Permission denied"},
-                status=status.HTTP_403_FORBIDDEN
+                {"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN
             )
 
         # Authorized – delete it
         comment.delete()
         return Response(
-            {"message": "Comment deleted"},
-            status=status.HTTP_204_NO_CONTENT
+            {"message": "Comment deleted"}, status=status.HTTP_204_NO_CONTENT
         )

--- a/townhall/townhall/asgi.py
+++ b/townhall/townhall/asgi.py
@@ -14,14 +14,14 @@ from channels.auth import AuthMiddlewareStack
 from django.core.asgi import get_asgi_application
 import townhall.routing
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'townhall.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "townhall.settings")
 django.setup()
 
-application = ProtocolTypeRouter({
-    "http": get_asgi_application(),
-    "websocket": AuthMiddlewareStack(
-        URLRouter(
-            townhall.routing.websocket_urlpatterns
-        )
-    ),
-})
+application = ProtocolTypeRouter(
+    {
+        "http": get_asgi_application(),
+        "websocket": AuthMiddlewareStack(
+            URLRouter(townhall.routing.websocket_urlpatterns)
+        ),
+    }
+)

--- a/townhall/townhall/routing.py
+++ b/townhall/townhall/routing.py
@@ -2,7 +2,7 @@ from django.urls import re_path
 from chats.consumers import ChatConsumer, UserConsumer, GroupConsumer
 
 websocket_urlpatterns = [
-    re_path(r'ws/chats/(?P<chat_id>\w+)/$', ChatConsumer.as_asgi()),
-    re_path(r'ws/groups/(?P<group_name>[^/]+)/$', GroupConsumer.as_asgi()),
-    re_path(r'ws/users/(?P<user_id>\w+)/$', UserConsumer.as_asgi()),
+    re_path(r"ws/chats/(?P<chat_id>\w+)/$", ChatConsumer.as_asgi()),
+    re_path(r"ws/groups/(?P<group_name>[^/]+)/$", GroupConsumer.as_asgi()),
+    re_path(r"ws/users/(?P<user_id>\w+)/$", UserConsumer.as_asgi()),
 ]

--- a/townhall/townhall/settings.py
+++ b/townhall/townhall/settings.py
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
     "townhallbackend.onrender.com",
     "atriacoop.netlify.app",
-    "townhallfrontend.onrender.com"
+    "townhallfrontend.onrender.com",
 ]
 
 APPEND_SLASH = True
@@ -57,9 +57,9 @@ INSTALLED_APPS = [
     "users",
     "posts",
     "chats",
-    'cloudinary',
-    'cloudinary_storage',
-    'channels',
+    "cloudinary",
+    "cloudinary_storage",
+    "channels",
 ]
 
 MIDDLEWARE = [
@@ -78,7 +78,7 @@ MIDDLEWARE = [
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SAMESITE = "None"
-SESSION_COOKIE_SAMESITE = 'None'
+SESSION_COOKIE_SAMESITE = "None"
 CSRF_COOKIE_HTTPONLY = False
 CSRF_COOKIE_DOMAIN = None
 SESSION_COOKIE_DOMAIN = None
@@ -203,12 +203,12 @@ DEBUG_TOOLBAR_PANELS = [
 
 
 # CLOUDINARY
-DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
+DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
 
 CLOUDINARY_STORAGE = {
-    'CLOUD_NAME': os.getenv('CLOUDINARY_CLOUD_NAME'),
-    'API_KEY': os.getenv('CLOUDINARY_API_KEY'),
-    'API_SECRET': os.getenv('CLOUDINARY_API_SECRET'),
+    "CLOUD_NAME": os.getenv("CLOUDINARY_CLOUD_NAME"),
+    "API_KEY": os.getenv("CLOUDINARY_API_KEY"),
+    "API_SECRET": os.getenv("CLOUDINARY_API_SECRET"),
 }
 
 CLOUDINARY_URL = (
@@ -218,9 +218,9 @@ CLOUDINARY_URL = (
 )
 
 cloudinary.config(
-  cloud_name=os.getenv('CLOUDINARY_CLOUD_NAME'),
-  api_key=os.getenv('CLOUDINARY_API_KEY'),
-  api_secret=os.getenv('CLOUDINARY_API_SECRET'),
+    cloud_name=os.getenv("CLOUDINARY_CLOUD_NAME"),
+    api_key=os.getenv("CLOUDINARY_API_KEY"),
+    api_secret=os.getenv("CLOUDINARY_API_SECRET"),
 )
 
 CHANNEL_LAYERS = {

--- a/townhall/townhall/urls.py
+++ b/townhall/townhall/urls.py
@@ -32,12 +32,12 @@ router = DefaultRouter()
 router.register(r"users", UserViewSet, basename="users")
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include(router.urls)),
-    path('', include('users.urls')),
-    path('', include('posts.urls')),
-    path('', include('chats.urls')),
-    path('', root),
+    path("admin/", admin.site.urls),
+    path("", include(router.urls)),
+    path("", include("users.urls")),
+    path("", include("posts.urls")),
+    path("", include("chats.urls")),
+    path("", root),
 ]
 
 # Serve media files even in production (temporary fix)

--- a/townhall/users/urls.py
+++ b/townhall/users/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
                 "post": "create_user",
             }
         ),
-        name="user"
+        name="user",
     ),
     path(
         "user/<int:user_id>/",
@@ -29,7 +29,7 @@ urlpatterns = [
                 "patch": "update_user",
             }
         ),
-        name="user_id"
+        name="user_id",
     ),
     path(
         "user/<int:pk>/complete_profile/",
@@ -38,8 +38,8 @@ urlpatterns = [
                 "post": "complete_profile",
             }
         ),
-        name="complete_profile"
-    )
+        name="complete_profile",
+    ),
 ] + debug_toolbar_urls()
 
 # Serve media files during development


### PR DESCRIPTION
## JIRA Ticket Link
https://atriadev.atlassian.net/browse/NT-93?atlOrigin=eyJpIjoiNDY0MmJhNmEzMzUwNGViMTg0NzI3ZDBlOWIwZmVkMjYiLCJwIjoiaiJ9

## Migrations Required?

NO :negative_squared_cross_mark:

## Summary (a few sentences describing what this PR is doing)
Implements presentation-time profanity masking for Posts (and Comment create) based on NT-93.
A new utility (posts/profanity.py) replaces listed swear words with * of the same length using case-insensitive, whole-word regex.
PostServices now applies masking right before returning data for get / list / create / update so database values remain unchanged

## Checks

- [:white_check_mark:] I have ran all the tests locally, and they all pass

## Impacted Areas in Application
Backend:
- posts/profanity.py (new utility)
- posts/services.py: masking applied on get_post, get_all_posts, create_post, update_post
- CommentServices.create_comment masks returned content (if present)
Tests
- posts/tests/test_profanity.py - unit tests for masking utility
- posts/tests/test_posts_services_masking.py - service-layer tests
API Behaviour
- Responses for Posts now show masked content; database remains raw
- No schema changes; no migrations

## Learnings
- Reinforced the value of service-layer business logic (one place to apply rules) vs. behaviour in views/serializers
- Practiced building a safe regex w/ word boundaries for false-positives and writing tests that patch DAOs to validate behaviour without touching the DB
- The whole process of using git to create a feature (branching, code, pull requests)
