### PR TITLE
Kan 5 dao and service post pagination

### DIFF
--- a/townhall/fixtures/post_fixture.json
+++ b/townhall/fixtures/post_fixture.json
@@ -6,8 +6,197 @@
       "user": 1,
       "content": "Hello World",
       "created_at": "2025-09-03T12:00:00Z",
-      "image": null,
       "likes": 0
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 2,
+    "fields": {
+      "user": 2,
+      "content": "My first post here!",
+      "created_at": "2025-09-04T09:15:00Z",
+      "likes": 3
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 3,
+    "fields": {
+      "user": 3,
+      "content": "Just finished a great book 📚",
+      "created_at": "2025-09-05T14:30:00Z",
+      "likes": 5
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 4,
+    "fields": {
+      "user": 4,
+      "content": "Excited to join this network!",
+      "created_at": "2025-09-06T18:45:00Z",
+      "likes": 2
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 5,
+    "fields": {
+      "user": 1,
+      "content": "Another update from Bob 🚧",
+      "created_at": "2025-09-07T08:20:00Z",
+      "likes": 7
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 6,
+    "fields": {
+      "user": 2,
+      "content": "Coffee is life ☕",
+      "created_at": "2025-09-08T10:00:00Z",
+      "likes": 1
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 7,
+    "fields": {
+      "user": 3,
+      "content": "Looking forward to the weekend!",
+      "created_at": "2025-09-09T16:10:00Z",
+      "likes": 4
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 8,
+    "fields": {
+      "user": 4,
+      "content": "Throwback thoughts from last year",
+      "created_at": "2025-09-10T20:00:00Z",
+      "likes": 10
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 9,
+    "fields": {
+      "user": 1,
+      "content": "Bob’s morning thoughts",
+      "created_at": "2025-09-11T09:00:00Z",
+      "likes": 2
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 10,
+    "fields": {
+      "user": 2,
+      "content": "Jerome loves coding!",
+      "created_at": "2025-09-12T11:30:00Z",
+      "likes": 5
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 11,
+    "fields": {
+      "user": 3,
+      "content": "Kate’s weekend update",
+      "created_at": "2025-09-13T15:00:00Z",
+      "likes": 3
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 12,
+    "fields": {
+      "user": 4,
+      "content": "Bernard’s new project",
+      "created_at": "2025-09-14T18:00:00Z",
+      "likes": 8
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 13,
+    "fields": {
+      "user": 1,
+      "content": "Bob shares tips",
+      "created_at": "2025-09-15T08:30:00Z",
+      "likes": 6
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 14,
+    "fields": {
+      "user": 2,
+      "content": "Jerome’s second post",
+      "created_at": "2025-09-16T12:15:00Z",
+      "likes": 4
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 15,
+    "fields": {
+      "user": 3,
+      "content": "Kate’s favorite quote",
+      "created_at": "2025-09-17T16:45:00Z",
+      "likes": 7
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 16,
+    "fields": {
+      "user": 4,
+      "content": "Bernard shares an idea",
+      "created_at": "2025-09-18T20:30:00Z",
+      "likes": 9
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 17,
+    "fields": {
+      "user": 1,
+      "content": "Bob’s reflection",
+      "created_at": "2025-09-19T07:50:00Z",
+      "likes": 3
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 18,
+    "fields": {
+      "user": 2,
+      "content": "Jerome’s morning coffee",
+      "created_at": "2025-09-20T10:10:00Z",
+      "likes": 2
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 19,
+    "fields": {
+      "user": 3,
+      "content": "Kate shares thoughts",
+      "created_at": "2025-09-21T14:20:00Z",
+      "likes": 5
+    }
+  },
+  {
+    "model": "posts.post",
+    "pk": 20,
+    "fields": {
+      "user": 4,
+      "content": "Bernard’s weekend plan",
+      "created_at": "2025-09-22T18:40:00Z",
+      "likes": 6
     }
   }
 ]

--- a/townhall/posts/daos.py
+++ b/townhall/posts/daos.py
@@ -18,6 +18,8 @@ class PostDao:
         return Post.objects.get(id=id)
 
     def get_all_posts(offset: int, limit: int) -> typing.List[Post]:
+        """Return a list of posts ordered by most recent,
+        paginated using offset and limit."""
         qs = Post.objects.order_by("-created_at")
         items = list(qs[offset : offset + limit])
         return items

--- a/townhall/posts/daos.py
+++ b/townhall/posts/daos.py
@@ -17,8 +17,10 @@ class PostDao:
     def get_post(id: int) -> typing.Optional[Post]:
         return Post.objects.get(id=id)
 
-    def get_all_posts() -> typing.List[Post]:
-        return Post.objects.all()
+    def get_all_posts(offset: int, limit: int) -> typing.List[Post]:
+        qs = Post.objects.order_by("-created_at")
+        items = list(qs[offset : offset + limit])
+        return items
 
     def create_post(post_data: CreatePostData) -> Post:
         print("Image type:", type(post_data.image))

--- a/townhall/posts/services.py
+++ b/townhall/posts/services.py
@@ -26,6 +26,7 @@ class PostServices:
 
     @staticmethod
     def get_all_posts(page: int = 1, limit: int = 10) -> typing.List[Post]:
+        """Return a paginated list of posts for a given page and limit."""
         page = max(1, page)
         limit = max(1, min(limit, 100))
         offset = (page - 1) * limit

--- a/townhall/posts/services.py
+++ b/townhall/posts/services.py
@@ -24,8 +24,12 @@ class PostServices:
             raise ValidationError(f"Post with the given id: {id}, does not exist.")
 
     @staticmethod
-    def get_all_posts() -> typing.List[Post]:
-        posts = PostDao.get_all_posts()
+    def get_all_posts(page: int = 1, limit: int = 10) -> typing.List[Post]:
+        page = max(1, page)
+        limit = max(1, min(limit, 100))
+        offset = (page - 1) * limit
+
+        posts = PostDao.get_all_posts(offset, limit)
         return _mask_content_list(posts)
 
     @staticmethod

--- a/townhall/posts/tests/test_post_pagination_service.py
+++ b/townhall/posts/tests/test_post_pagination_service.py
@@ -1,0 +1,99 @@
+from django.test import TestCase
+from django.core.management import call_command
+
+from posts.services import PostServices
+from posts.models import Post
+
+
+class TestPostPaginationService(TestCase):
+    def setUp(self):
+        call_command("loaddata", "fixtures/user_fixture.json", verbosity=0)
+        call_command("loaddata", "fixtures/post_fixture.json", verbosity=0)
+
+    def test_posts_with_pagination_success(self):
+        # Arrange
+        page = 1
+        limit = 10
+
+        # Act
+        posts = PostServices.get_all_posts(page=page, limit=limit)
+
+        # Assert
+        self.assertEqual(len(posts), 10)
+        self.assertTrue(posts[0].created_at > posts[-1].created_at)
+
+    def test_posts_with_pagination_defaults(self):
+        # Act
+        posts = PostServices.get_all_posts()
+
+        # Assert
+        self.assertEqual(len(posts), 10)
+        self.assertTrue(posts[0].created_at > posts[-1].created_at)
+
+    def test_posts_with_pagination_second_page(self):
+        # Arrange
+        page = 2
+        limit = 8
+
+        # Act
+        posts = PostServices.get_all_posts(page=page, limit=limit)
+
+        # Assert
+        self.assertEqual(len(posts), 8)
+        self.assertTrue(posts[0].created_at > posts[-1].created_at)
+
+    def test_posts_with_pagination_invalid_page(self):
+        # Arrange
+        page = -1
+        limit = 5
+
+        # Act
+        posts = PostServices.get_all_posts(page=page, limit=limit)
+
+        # Assert
+        self.assertEqual(len(posts), 5)
+        self.assertTrue(posts[0].created_at > posts[-1].created_at)
+
+    def test_posts_with_pagination_invalid_limit(self):
+        # Arrange
+        page = 1
+        limit = 0
+
+        # Act
+        posts = PostServices.get_all_posts(page=page, limit=limit)
+
+        # Assert
+        self.assertEqual(len(posts), 1)
+
+    def test_posts_with_pagination_limit_exceed(self):
+        # Arrange
+        page = 1
+        limit = 1000
+        total_posts = Post.objects.count()
+
+        # Act
+        posts = PostServices.get_all_posts(page=page, limit=limit)
+
+        # Assert
+        self.assertEqual(len(posts), total_posts)
+
+    def test_posts_with_pagination_empty(self):
+        # Arrange
+        Post.objects.all().delete()
+
+        # Act
+        posts = PostServices.get_all_posts(page=1, limit=10)
+
+        # Assert
+        self.assertEqual(len(posts), 0)
+
+    def test_posts_with_pagination_page_beyond_posts(self):
+        # Arrange
+        page = 1000
+        limit = 5
+
+        # Act
+        posts = PostServices.get_all_posts(page=page, limit=limit)
+
+        # Assert
+        self.assertEqual(len(posts), 0)


### PR DESCRIPTION
## JIRA Ticket Link

https://anselatria2.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-5

## Migrations Required?

NO :negative_squared_cross_mark:

## Summary (a few sentences describing what this PR is doing)

Updated DAO and Service methods for get_all_posts, to handle page number and limit for pagination.
Also added more data into posts fixture (for testing pagination).

## Checks

- [x] I have ran all the tests locally, and they all pass

## Impacted Areas in Application

- fixtures/post_fixture.json
- post/services.py
- post/daos.py
