### PR TITLE
fix: post api call now hides anonymous user data. also refactored pos…

### DIFF
--- a/townhall/posts/serializers.py
+++ b/townhall/posts/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from users.serializers import UserMiniSerializer
 from .models import Reaction, ReportedPost, User, Post, Comment
+from .profanity import censor_text
 
 
 class CreateCommentSerializer(serializers.ModelSerializer):
@@ -8,6 +9,22 @@ class CreateCommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = ["id", "post", "content", "created_at", "anonymous"]
+
+
+class PostCreateUpdateSerializer(serializers.ModelSerializer):
+    content = serializers.CharField(max_length=1000)
+    image = serializers.ImageField(required=False, allow_null=True)
+    tags = serializers.ListField(child=serializers.CharField(), required=False)
+
+    class Meta:
+        model = Post
+        fields = [
+            "content",
+            "image",
+            "tags",
+            "pinned",
+            "anonymous",
+        ]
 
 
 class CommentUserMiniSerializer(serializers.ModelSerializer):
@@ -24,15 +41,29 @@ class CommentUserMiniSerializer(serializers.ModelSerializer):
 
 
 class CommentSerializer(serializers.ModelSerializer):
-    user = CommentUserMiniSerializer(read_only=True)
+    user = serializers.SerializerMethodField()
+    content = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
         fields = ["id", "user", "post", "content", "created_at", "anonymous"]
 
+    def get_user(self, obj):
+        request = self.context.get("request")
+
+        if obj.anonymous:
+            if request and request.user.id == obj.user_id:
+                return CommentUserMiniSerializer(obj.user).data  # show to owner
+            return None  # hide from others
+
+        return CommentUserMiniSerializer(obj.user).data
+
+    def get_content(self, obj):
+        return censor_text(obj.content)
+
 
 class PostSerializer(serializers.ModelSerializer):
-    user = UserMiniSerializer(read_only=True)
+    user = serializers.SerializerMethodField()
 
     image = serializers.ImageField(required=False, allow_null=True)
 
@@ -44,7 +75,7 @@ class PostSerializer(serializers.ModelSerializer):
 
     tags = serializers.SerializerMethodField()
 
-    content = serializers.CharField(max_length=1000)
+    content = serializers.SerializerMethodField()
 
     class Meta:
         model = Post
@@ -90,6 +121,20 @@ class PostSerializer(serializers.ModelSerializer):
     def get_tags(self, obj):
         """Return a list of tag names instead of tag IDs"""
         return [tag.name for tag in obj.tags.all()]
+
+    def get_user(self, obj):
+        request = self.context.get("request")
+
+        if obj.anonymous:
+            # Show User Name to Owner, else Hide
+            if request and request.user.id == obj.user_id:
+                return UserMiniSerializer(obj.user).data
+            return None
+
+        return UserMiniSerializer(obj.user).data
+
+    def get_content(self, obj):
+        return censor_text(obj.content)
 
 
 class ReportedPostSerializer(serializers.ModelSerializer):

--- a/townhall/posts/services.py
+++ b/townhall/posts/services.py
@@ -14,7 +14,7 @@ from .types import (
 )
 from .daos import PostDao, CommentDao, ReportedPostDao, ReactionDao
 from users.models import User
-from .profanity import censor_text, _CENSOR_RE
+from .profanity import _CENSOR_RE
 
 
 class PostServices:
@@ -25,7 +25,7 @@ class PostServices:
     def get_post(id: int) -> typing.Optional[Post]:
         try:
             post = PostDao.get_post(id=id)
-            return _mask_content_instance(post)
+            return post
         except Post.DoesNotExist:
             raise ValidationError(f"Post with the given id: {id}, does not exist.")
 
@@ -41,7 +41,7 @@ class PostServices:
 
         posts, total_count = PostDao.get_all_posts(offset, limit, tag_names)
         total_pages = (total_count + limit - 1) // limit
-        return _mask_content_list(posts), total_pages
+        return posts, total_pages
 
     @staticmethod
     def get_trending_tags(limit: int = 10) -> list[dict]:
@@ -59,7 +59,7 @@ class PostServices:
 
         post = PostDao.create_post(post_data=create_post_data)
 
-        return _mask_content_instance(post)
+        return post
 
     @staticmethod
     def update_post(id: int, update_post_data: UpdatePostData) -> Post:
@@ -73,7 +73,7 @@ class PostServices:
 
         post = PostDao.update_post(id=id, post_data=update_post_data)
 
-        return _mask_content_instance(post)
+        return post
 
     @staticmethod
     def delete_post(post_id: int) -> None:
@@ -116,6 +116,11 @@ class PostServices:
                     f"Tag '{tag_name}' contains inappropriate language."
                 )
 
+    @staticmethod
+    def _validate_content(content: str):
+        if content and _CENSOR_RE.search(content):
+            raise ValidationError("Content contains inappropriate language.")
+
 
 class CommentServices:
     @staticmethod
@@ -124,26 +129,11 @@ class CommentServices:
 
     @staticmethod
     def create_comment(create_comment_data: CreateCommentData) -> None:
-        comment = CommentDao.create_comment(create_comment_data=create_comment_data)
-        if hasattr(comment, "content"):
-            comment.content = censor_text(comment.content)
-        return comment
+        return CommentDao.create_comment(create_comment_data=create_comment_data)
 
     @staticmethod
     def update_comment(id: int, update_comment_data: UpdateCommentData) -> Comment:
-        comment = CommentDao.update_comment(id, update_comment_data)
-        return _mask_content_instance(comment)
-
-
-# Masking helpers
-def _mask_content_instance(object) -> typing.Any:
-    if hasattr(object, "content"):
-        object.content = censor_text(object.content)
-    return object
-
-
-def _mask_content_list(objects: typing.Iterable) -> typing.List:
-    return [_mask_content_instance(object) for object in objects]
+        return CommentDao.update_comment(id, update_comment_data)
 
 
 class ReportedPostServices:

--- a/townhall/posts/tests/test_comment_endpoint.py
+++ b/townhall/posts/tests/test_comment_endpoint.py
@@ -28,7 +28,7 @@ class CommentEndpointTests(TestCase):
 
         # Act
         response = self.client.patch(self.url, payload, format="json")
-        print(response.data)
+
         # Assert
         self.assertEqual(response.status_code, 200)
         self.comment.refresh_from_db()

--- a/townhall/posts/tests/test_comment_endpoint.py
+++ b/townhall/posts/tests/test_comment_endpoint.py
@@ -28,7 +28,7 @@ class CommentEndpointTests(TestCase):
 
         # Act
         response = self.client.patch(self.url, payload, format="json")
-
+        print(response.data)
         # Assert
         self.assertEqual(response.status_code, 200)
         self.comment.refresh_from_db()

--- a/townhall/posts/tests/test_comment_serialization.py
+++ b/townhall/posts/tests/test_comment_serialization.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.core.management import call_command
+
+from posts.models import Comment
+
+from posts.serializers import (
+    CommentSerializer,
+)
+
+
+class TestCommentSerialization(TestCase):
+    def setUp(self):
+        call_command("loaddata", "fixtures/user_fixture.json", verbosity=0)
+        call_command("loaddata", "fixtures/post_fixture.json", verbosity=0)
+        call_command("loaddata", "fixtures/comment_fixture.json", verbosity=0)
+
+    def test_comment_serializer_censors(self):
+        comment = Comment(content="hell", anonymous=False, user=None)
+
+        serializer = CommentSerializer(comment, context={"request": None})
+        data = serializer.data
+
+        self.assertEqual(data["content"], "****")

--- a/townhall/posts/tests/test_comment_service.py
+++ b/townhall/posts/tests/test_comment_service.py
@@ -52,5 +52,8 @@ class TestCommentService(TestCase):
         )
 
         # Assert
-        self.assertEqual(updated_comment.content, "****")
+        # Service returns RAW content
+        self.assertEqual(updated_comment.content, "hell")
+
+        # DB stores RAW content
         self.assertEqual(Comment.objects.get(pk=1).content, "hell")

--- a/townhall/posts/tests/test_post_serialization.py
+++ b/townhall/posts/tests/test_post_serialization.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from django.core.management import call_command
+
+from posts.serializers import (
+    PostSerializer,
+)
+
+from posts.models import Post
+
+
+class TestPostSerialization(TestCase):
+    def setUp(self):
+        call_command("loaddata", "fixtures/user_fixture.json", verbosity=0)
+        call_command("loaddata", "fixtures/post_fixture.json", verbosity=0)
+        call_command("loaddata", "fixtures/comment_fixture.json", verbosity=0)
+
+    def test_post_serializer_censors_content(self):
+        post = Post.objects.create(content="you BITCH!", anonymous=False, user=None)
+
+        serializer = PostSerializer(post, context={"request": None})
+        data = serializer.data
+
+        self.assertEqual(
+            data["content"],
+            "you *****!",
+        )
+
+    def test_post_serializer_censors_list(self):
+        posts = [
+            Post.objects.create(content="shit happens", anonymous=False, user=None)
+        ]
+
+        serializer = PostSerializer(posts, many=True, context={"request": None})
+        data = serializer.data
+
+        self.assertEqual(data[0]["content"], "**** happens")

--- a/townhall/posts/tests/test_posts_services_masking.py
+++ b/townhall/posts/tests/test_posts_services_masking.py
@@ -10,22 +10,27 @@ from posts.types import CreatePostData, UpdatePostData
 
 class PostServicesMaskingTests(SimpleTestCase):
     @patch("posts.services.PostDao.get_all_posts")
-    def test_get_all_posts_masks(self, mock_get_all):
+    def test_get_all_posts(self, mock_get_all):
         mock_get_all.return_value = ([SimpleNamespace(content="shit happens")], 1)
+
         posts, total_pages = PostServices.get_all_posts()
-        self.assertEqual(posts[0].content, "**** happens")
+
+        # Service returns RAW content now
+        self.assertEqual(posts[0].content, "shit happens")
         self.assertEqual(total_pages, 1)
 
     @patch("posts.services.PostDao.get_post")
-    def test_get_post_masks(self, mock_get):
+    def test_get_post(self, mock_get):
         mock_get.return_value = SimpleNamespace(content="you asshole")
+
         post = PostServices.get_post(1)
-        self.assertEqual(post.content, "you *******")
+
+        # Service returns RAW content now
+        self.assertEqual(post.content, "you asshole")
 
     @patch("posts.services.User.objects.get")
     @patch("posts.services.PostDao.create_post")
-    def test_create_post_masks(self, mock_create, mock_user_get):
-        # Return whatever the DAO would have saved — we only care about masking.
+    def test_create_post(self, mock_create, mock_user_get):
         mock_create.return_value = SimpleNamespace(content="damn this bug")
         mock_user_get.return_value = SimpleNamespace(is_staff=False)
 
@@ -34,14 +39,19 @@ class PostServicesMaskingTests(SimpleTestCase):
         )
 
         post = PostServices.create_post(post_data)
-        self.assertEqual(post.content, "**** this bug")
+
+        # Service now returns RAW content
+        self.assertEqual(post.content, "damn this bug")
 
     @patch("posts.services.User.objects.get")
     @patch("posts.services.PostDao.update_post")
-    def test_update_post_masks(self, mock_update, mock_user_get):
+    def test_update_post(self, mock_update, mock_user_get):
         mock_update.return_value = SimpleNamespace(content="you BITCH!")
         mock_user_get.return_value = SimpleNamespace(is_staff=False)
+
         update_data = UpdatePostData(content="you BITCH!", user_id=1)
 
         post = PostServices.update_post(1, update_data)
-        self.assertEqual(post.content, "you *****!")
+
+        # Service returns RAW content now
+        self.assertEqual(post.content, "you BITCH!")

--- a/townhall/posts/views.py
+++ b/townhall/posts/views.py
@@ -19,6 +19,7 @@ from .types import (
 )
 from .serializers import (
     PostSerializer,
+    PostCreateUpdateSerializer,
     CreateCommentSerializer,
     CommentSerializer,
     ReportedPostSerializer,
@@ -42,7 +43,7 @@ class PostViewSet(viewsets.ModelViewSet):
     def get_post(self, request, pk=None):
         try:
             post = PostServices.get_post(id=pk)
-            serializer = PostSerializer(post)
+            serializer = PostSerializer(post, context={"request": request})
             return Response(
                 {
                     "message": "Post fetched successfully",
@@ -71,7 +72,7 @@ class PostViewSet(viewsets.ModelViewSet):
             )
 
             posts, total_pages = PostServices.get_all_posts(page, limit, tag_names)
-            serializer = PostSerializer(posts, many=True)
+            serializer = PostSerializer(posts, context={"request": request}, many=True)
             return Response(
                 {
                     "message": "Posts fetched successfully",
@@ -112,7 +113,7 @@ class PostViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
 
-        serializer = PostSerializer(data=request.data)
+        serializer = PostCreateUpdateSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(
@@ -136,7 +137,7 @@ class PostViewSet(viewsets.ModelViewSet):
 
         try:
             post = PostServices.create_post(create_post_data)
-            response_serializer = PostSerializer(post)
+            response_serializer = PostSerializer(post, context={"request": request})
             return Response(
                 {
                     "message": "Post Created Successfully",
@@ -174,7 +175,7 @@ class PostViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        serializer = PostSerializer(post, data=request.data, partial=True)
+        serializer = PostCreateUpdateSerializer(post, data=request.data, partial=True)
         if not serializer.is_valid():
             return Response(
                 serializer.errors,
@@ -398,7 +399,7 @@ class PostViewSet(viewsets.ModelViewSet):
                 except Exception:
                     pass
 
-            serializer = PostSerializer(post)
+            serializer = PostSerializer(post, context={"request": request})
 
             return Response(
                 {
@@ -488,7 +489,9 @@ class CommentViewSet(viewsets.ModelViewSet):
             except Exception:
                 pass
 
-            response_serializer = CommentSerializer(comment)
+            response_serializer = CommentSerializer(
+                comment, context={"request": request}
+            )
 
             return Response(
                 {
@@ -525,7 +528,9 @@ class CommentViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        serializer = CommentSerializer(comment, data=request.data, partial=True)
+        serializer = CreateCommentSerializer(
+            comment, data=request.data, partial=True, context={"request": request}
+        )
         if not serializer.is_valid():
             return Response(
                 serializer.errors,


### PR DESCRIPTION
…t & comment serializer.

## JIRA Ticket Link

https://atriadev.atlassian.net/jira/software/projects/AFR/boards/5?selectedIssue=AFR-198

## Migrations Required?

NO :negative_squared_cross_mark:

## Summary (a few sentences describing what this PR is doing)

Anonymous post privacy API requests still returned user data. This branch stops the back-end from passing back anonymous data. (specifically the User data)

In doing so, I refactored parts of Posts and Comments Serializer.
**Exact changes are listed in JIRA ticket.**

One change that might stand out is the removal of the profanity mask from the Service Layer into the Serializer. Comment post profanity's were not being removed because the Serializer bypassed the masking. This is why I have anonymous data filtering in the Serializer. And to organize it with my anonymous data filtering I moved the profanity filter as well.

Also fixed post tests.

## Extra

Also I apologize, I know this ticket fixes a few other issues. It was just so adjacent to my current bug, I decided to fix it all.

## Checks

- [x] I have ran all the tests locally, and they all pass

## Impacted Areas in Application

- posts/serializers.py
- posts/services.py
- posts/tests/...